### PR TITLE
Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -220,12 +220,12 @@ func (c *Context) Return(body ...interface{}) error {
 }
 
 // HashedReturn returns response with ETag header calculated hash of response.Body dynamically
-func (c *Context) HashedReturn(hashType crypto.Hash, body ...interface{}) error {
+func (c *Context) HashedReturn(hasher crypto.Hash, body ...interface{}) error {
 	if len(body) > 0 {
-		return c.Render(NewHashRender(c.Response, hashType), body[0])
+		return c.Render(NewHashRender(c.Response, hasher), body[0])
 	}
 
-	return c.Render(NewHashRender(c.Response, hashType), "")
+	return c.Render(NewHashRender(c.Response, hasher), "")
 }
 
 // Text returns response with Content-Type: text/plain header

--- a/context.go
+++ b/context.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"math"
 	"net/http"
+	"strings"
 	"sync"
 )
 
@@ -130,16 +131,36 @@ func (c *Context) MustGetFinal(key string) interface{} {
 	return value
 }
 
-// HasHeader returns true if request sets its header for specified key
-func (c *Context) HasHeader(key string) bool {
-	key = http.CanonicalHeaderKey(key)
+// HasRawHeader returns true if request sets its header with specified key
+func (c *Context) HasRawHeader(key string) bool {
+	for yek, _ := range c.Request.Header {
+		if key == yek {
+			return true
+		}
+	}
 
-	_, ok := c.Request.Header[key]
+	return false
+}
+
+// RawHeader returns request header value of specified key
+func (c *Context) RawHeader(key string) string {
+	for yek, val := range c.Request.Header {
+		if key == yek {
+			return strings.Join(val, ",")
+		}
+	}
+
+	return ""
+}
+
+// HasHeader returns true if request sets its header for canonicaled specified key
+func (c *Context) HasHeader(key string) bool {
+	_, ok := c.Request.Header[http.CanonicalHeaderKey(key)]
 
 	return ok
 }
 
-// Header returns request header value of specified key
+// Header returns request header value of canonicaled specified key
 func (c *Context) Header(key string) string {
 	return c.Request.Header.Get(key)
 }

--- a/context.go
+++ b/context.go
@@ -131,6 +131,16 @@ func (c *Context) MustGetFinal(key string) interface{} {
 	return value
 }
 
+// RequestURI returns request raw uri
+func (c *Context) RequestURI() string {
+	return c.Request.RequestURI
+}
+
+// RequestID returns x-request-id value
+func (c *Context) RequestID() string {
+	return c.Logger.RequestId()
+}
+
 // HasRawHeader returns true if request sets its header with specified key
 func (c *Context) HasRawHeader(key string) bool {
 	for yek, _ := range c.Request.Header {

--- a/errors.go
+++ b/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrHeaderFlushed = errors.New("Response headers have been written!")
 	ErrConfigSection = errors.New("Config section does not exist!")
 	ErrSettingsKey   = errors.New("Settings key is duplicated!")
+	ErrHash          = errors.New("The hash function does not linked into the binary!")
 )

--- a/render_test.go
+++ b/render_test.go
@@ -75,7 +75,7 @@ func Test_HashRender(t *testing.T) {
 	render.Render("Hello, world!")
 	assertion.Equal(http.StatusOK, recorder.Code)
 	assertion.Equal(render.ContentType(), recorder.Header().Get("Content-Type"))
-	assertion.Equal("6cd3556deb0da54bca060b4c39479839", recorder.Header().Get("ETag"))
+	assertion.Equal("6cd3556deb0da54bca060b4c39479839", recorder.Header().Get("Etag"))
 	assertion.Equal("Hello, world!", recorder.Body.String())
 }
 
@@ -96,7 +96,7 @@ func Test_HashRenderWithReader(t *testing.T) {
 	assertion.Equal(http.StatusOK, recorder.Code)
 	assertion.Equal(render.ContentType(), recorder.Header().Get("Content-Type"))
 	assertion.Equal(fmt.Sprintf("%d", len(s)), recorder.Header().Get("Content-Length"))
-	assertion.Equal("bc7f283e5babc5ed5e231c9bf961af1a", recorder.Header().Get("ETag"))
+	assertion.Equal("bc7f283e5babc5ed5e231c9bf961af1a", recorder.Header().Get("Etag"))
 	assertion.Equal(s, recorder.Body.String())
 }
 

--- a/response.go
+++ b/response.go
@@ -52,7 +52,7 @@ func (r *Response) WriteHeader(code int) {
 		r.status = code
 
 		if r.HeaderFlushed() {
-			log.Println(ErrHeaderFlushed.Error())
+			log.Println("[WARN] ", ErrHeaderFlushed.Error())
 		}
 	}
 }

--- a/route.go
+++ b/route.go
@@ -48,7 +48,6 @@ func (r *AppRoute) Handle(method string, path string, handler Middleware) {
 		ctx := r.server.new(resp, req, NewAppParams(req, params), handlers)
 
 		t := time.Now()
-
 		ctx.Logger.Infof(`Started %s "%s"`, req.Method, r.filterParameters(req.URL))
 
 		ctx.Next()
@@ -69,7 +68,6 @@ func (r *AppRoute) MockHandle(method string, path string, response http.Response
 		ctx := r.server.new(response, req, NewAppParams(req, params), handlers)
 
 		t := time.Now()
-
 		ctx.Logger.Infof(`Started %s "%s"`, req.Method, r.filterParameters(req.URL))
 
 		ctx.Next()


### PR DESCRIPTION
- fix `ctx.Render` issue with filter chain

- new `ctx.HasRawHeader` and `ctx.RawHeader` helpers for reading request header without canonical key

- new `ctx.RequestURI` and `ctx.RequestID` helpers for shortcut 

- refactor `HashRender`