### PR TITLE
What: fix parse form issue with ctx.Params.RawBody

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   - 1.6
   - 1.7
-  - 1.10.
+  - 1.10.1
 
 before_script:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   - 1.6
   - 1.7
-  - tip
+  - 1.10.
 
 before_script:
 

--- a/param.go
+++ b/param.go
@@ -68,11 +68,14 @@ func (p *AppParams) RawBody() ([]byte, error) {
 
 	p.rawBody, p.rawErr = ioutil.ReadAll(p.request.Body)
 
-	// close the request.Body
+	// close and hijack the request.Body
 	if p.rawErr == nil {
 		p.request.Body.Close()
+
+		p.request.Body = ioutil.NopCloser(bytes.NewReader(p.rawBody))
 	}
 
+	// mark as readed
 	p.readed = true
 
 	return p.rawBody, p.rawErr

--- a/param_test.go
+++ b/param_test.go
@@ -40,11 +40,13 @@ func Test_AppParamsHasForm(t *testing.T) {
 }
 
 func Test_AppParamsRawBody(t *testing.T) {
+	assertion := assert.New(t)
+
 	params := url.Values{}
 	params.Add("key", "name")
 
-	request, _ := http.NewRequest("PUT", "/path/to/resource?test&key=url_value", bytes.NewBufferString(params.Encode()))
-	assertion := assert.New(t)
+	request, _ := http.NewRequest("POST", "/path/to/resource?test&key=url_value", bytes.NewBufferString(params.Encode()))
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
 
 	p := NewAppParams(request, httpdispatch.Params{})
 
@@ -52,10 +54,16 @@ func Test_AppParamsRawBody(t *testing.T) {
 	assertion.Nil(err)
 	assertion.Equal(params.Encode(), string(body))
 
+	// original FormValue should works also
+	assertion.Equal(params.Get("key"), request.FormValue("key"))
+
 	// safe to invoke more than one time
 	body, err = p.RawBody()
 	assertion.Nil(err)
 	assertion.Equal(params.Encode(), string(body))
+
+	// original FormValue should works also
+	assertion.Equal(params.Get("key"), request.FormValue("key"))
 }
 
 func Test_AppParamsGet(t *testing.T) {


### PR DESCRIPTION
Why:

  * hijack request body after invoking ctx.Params.RawBody()

How:

  * nop